### PR TITLE
make reader return data, meta

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -269,7 +269,8 @@ class QtViewer(QSplitter):
             for fname in filenames:
                 for check, read in plugin_manager.readers:
                     if check(fname):
-                        read(fname, self.viewer)
+                        data, meta = read(fname)
+                        self.viewer.add_image(data, **meta)
                         return
             self.viewer.add_image(path=filenames)
             self._last_visited_dir = os.path.dirname(filenames[0])

--- a/napari_io_lls/__init__.py
+++ b/napari_io_lls/__init__.py
@@ -29,16 +29,21 @@ def is_lls_folder(path):
 # two options here... the reader can either accept the viewer instance, and
 # call viewer.add_image (or even other layers) itself,
 # or it can return args and kwargs that would be passed to viewer.add_image
-# the first case is implemented here
-def read_lls_folder(directory, viewer):
-    """Take a directory and load images in the viewer
+# the second case is implemented here
+def read_lls_folder(directory):
+    """Take a directory and return image data and metadata
     
     Parameters
     ----------
     directory : str
         Path to directory
-    viewer : napari.Viewer
-        viewer instance
+    
+    Returns
+    -------
+    data : array
+        Image array data
+    meta : dict
+        Image metadata dictionary.
     """
     i = 0
     channels = []
@@ -73,8 +78,13 @@ def read_lls_folder(directory, viewer):
     stack = da.stack(channels)
     scale = [1] * stack.ndim
     scale[-3] = dz / dx
-    viewer.add_image(stack, channel_axis=0, rgb=False, scale=scale, name=waves)
-    viewer.dims.ndisplay = 3
+    meta = {
+        'channel_axis': 0,
+        'rgb': False,
+        'scale': scale,
+        'name': waves,
+    }
+    return stack, meta
 
 
 """


### PR DESCRIPTION
# Description
Following discussions in https://github.com/napari/napari/pull/891 this PR makes the reader now return a `data`, `meta` tuple that is passed as an input argument to `add_image`. This allows this reader to be used again by many tools and in many contexts, not just adding data to the napari viewer.

Note I think this meets the request from @jni of:
> I would like IO plugins to be similar to functional plugins, meaning something that takes in a PathLike and returns an {ArrayLike, Image, Coords, Paths, WhateversThatHasARegisteredLayer}.

Overall, @tlambert03 requested the following:

> just to list some desirable goals for this (as I see it):
>
> - should be able to add (an arbitrary number of) different layer types to the viewer
> - should be able to set name, scale, color, other props, etc... on each layer
> - would be nice to control dims as well (e.g. label dims, set ndisplay = 3)

Things in the flavour of this PR would satisfy the second bullet well I think.

Right now we still need to think exactly about how to address the first bullet - which really consists of two things - supporting different layer types, and supporting multiple calls to an `add_*` method with one drag and drop say.

To support other layer types we could either just have an optional special meta keyword called `layer_type='Shapes'` say and then do some parsing of that in maybe a general method `add_layer`. We discussed some of this stuff back in https://github.com/napari/napari/pull/723 where there was an `add_layer_by_type` method at one point in time. Another way would be to use function annotations and our yet to be developed image-types package. Using the `layer_type` keyword arg certainly seems simpler for now (note if not provided, we'll default to calling `add_image`) and would be my vote.

To support adding multiple layers we could have the reader return a list of `[(data_1, meta_1), (data_2, meta_2)]` etc. This would even allow you to add multiple layers of different types, which I see as really important say for adding an image and some points on top of it. One question though is should we always force a list? If not then should we always force a `meta` even if it is an empty dictionary? I'm worried if we just get a list, is that just pyramid data for an image layer, or is it a list of data arrays for separate calls. I like the idea of forcing an empty meta dict. This should be discussed further, in general we havn't done so well with our APIs when we've had to guess things.

> - would be nice to control dims as well (e.g. label dims, set ndisplay = 3)

This bullet is more complex, given that our `add_*` methods don't support editing these, I'm not sure that I think these should be accessible to IO plugins until the `add_*` methods support them (for example, we've had some discussion in https://github.com/napari/napari/issues/14 about passing xarrays that change the dims labels, or we rethink what it means to update the viewer / dims / camera more broadly, which is happening as part of some of the viewer serialization efforts. We might want to hold off on this one for a bit.

How does all this sound @tlambert03? 