### PR TITLE
Remove build-system from pyproject.toml so we can still pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ exclude = '''
 )
 '''
 
-[build-system]
-requires = ["briefcase"]
-
 [tool.briefcase]
 project_name = "napari"
 bundle = "com.napari"


### PR DESCRIPTION
Right now the build-system in your pyproject.toml means we are unable to pip install napari. Removing these lines means we fall back on the default (including setuptools and wheel, which is what we want), while still allowing briefcase to work just fine.

See https://github.com/beeware/briefcase-template/pull/20 for a more detailed discussion.

I've confirmed this here (the Mac app can be downloaded, installed & run just fine; Windows & Linux still need unrelated issues fixed): https://github.com/GenevieveBuckley/napari/actions/runs/114494382