### PR TITLE
Add pytest.ini so briefcase won't stop pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = napari/


### PR DESCRIPTION
If you've created an app bundle with briefcase, a copy of all the source code including tests gets stored in that bundle folder (macOS, windows, linux). That means pytest gets confused, because it's trying to collect tests from the source code, as well as from all the bundles & that doesn't go so well. This change avoids the issue entirely.